### PR TITLE
Moteurs branch

### DIFF
--- a/DynamixelWorkbench/include/dynamixel_workbench_toolbox/WString.h
+++ b/DynamixelWorkbench/include/dynamixel_workbench_toolbox/WString.h
@@ -1,0 +1,230 @@
+/*
+  WString.h - String library for Wiring & Arduino
+  ...mostly rewritten by Paul Stoffregen...
+  Copyright (c) 2009-10 Hernando Barragan.  All right reserved.
+  Copyright 2011, Paul Stoffregen, paul@pjrc.com
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef String_class_h
+#define String_class_h
+#ifdef __cplusplus
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <avr/pgmspace.h>
+
+// When compiling programs with this class, the following gcc parameters
+// dramatically increase performance and memory (RAM) efficiency, typically
+// with little or no increase in code size.
+//     -felide-constructors
+//     -std=c++0x
+
+class __FlashStringHelper;
+#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
+
+// An inherited class for holding the result of a concatenation.  These
+// result objects are assumed to be writable by subsequent concatenations.
+class StringSumHelper;
+
+// The string class
+class String
+{
+	// use a function pointer to allow for "if (s)" without the
+	// complications of an operator bool(). for more information, see:
+	// http://www.artima.com/cppsource/safebool.html
+	typedef void (String::*StringIfHelperType)() const;
+	void StringIfHelper() const {}
+
+public:
+	// constructors
+	// creates a copy of the initial value.
+	// if the initial value is null or invalid, or if memory allocation
+	// fails, the string will be marked as invalid (i.e. "if (s)" will
+	// be false).
+	String(const char *cstr = "");
+	String(const String &str);
+	String(const __FlashStringHelper *str);
+       #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	String(String &&rval);
+	String(StringSumHelper &&rval);
+	#endif
+	explicit String(char c);
+	explicit String(unsigned char, unsigned char base=10);
+	explicit String(int, unsigned char base=10);
+	explicit String(unsigned int, unsigned char base=10);
+	explicit String(long, unsigned char base=10);
+	explicit String(unsigned long, unsigned char base=10);
+	explicit String(float, unsigned char decimalPlaces=2);
+	explicit String(double, unsigned char decimalPlaces=2);
+	~String(void);
+
+	// memory management
+	// return true on success, false on failure (in which case, the string
+	// is left unchanged).  reserve(0), if successful, will validate an
+	// invalid string (i.e., "if (s)" will be true afterwards)
+	unsigned char reserve(unsigned int size);
+	inline unsigned int length(void) const {return len;}
+
+	// creates a copy of the assigned value.  if the value is null or
+	// invalid, or if the memory allocation fails, the string will be
+	// marked as invalid ("if (s)" will be false).
+	String & operator = (const String &rhs);
+	String & operator = (const char *cstr);
+	String & operator = (const __FlashStringHelper *str);
+       #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	String & operator = (String &&rval);
+	String & operator = (StringSumHelper &&rval);
+	#endif
+
+	// concatenate (works w/ built-in types)
+
+	// returns true on success, false on failure (in which case, the string
+	// is left unchanged).  if the argument is null or invalid, the
+	// concatenation is considered unsucessful.
+	unsigned char concat(const String &str);
+	unsigned char concat(const char *cstr);
+	unsigned char concat(char c);
+	unsigned char concat(unsigned char c);
+	unsigned char concat(int num);
+	unsigned char concat(unsigned int num);
+	unsigned char concat(long num);
+	unsigned char concat(unsigned long num);
+	unsigned char concat(float num);
+	unsigned char concat(double num);
+	unsigned char concat(const __FlashStringHelper * str);
+
+	// if there's not enough memory for the concatenated value, the string
+	// will be left unchanged (but this isn't signalled in any way)
+	String & operator += (const String &rhs)	{concat(rhs); return (*this);}
+	String & operator += (const char *cstr)		{concat(cstr); return (*this);}
+	String & operator += (char c)			{concat(c); return (*this);}
+	String & operator += (unsigned char num)		{concat(num); return (*this);}
+	String & operator += (int num)			{concat(num); return (*this);}
+	String & operator += (unsigned int num)		{concat(num); return (*this);}
+	String & operator += (long num)			{concat(num); return (*this);}
+	String & operator += (unsigned long num)	{concat(num); return (*this);}
+	String & operator += (float num)		{concat(num); return (*this);}
+	String & operator += (double num)		{concat(num); return (*this);}
+	String & operator += (const __FlashStringHelper *str){concat(str); return (*this);}
+
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, char c);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, int num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, long num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, float num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, double num);
+	friend StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHelper *rhs);
+
+	// comparison (only works w/ Strings and "strings")
+	operator StringIfHelperType() const { return buffer ? &String::StringIfHelper : 0; }
+	int compareTo(const String &s) const;
+	unsigned char equals(const String &s) const;
+	unsigned char equals(const char *cstr) const;
+	unsigned char operator == (const String &rhs) const {return equals(rhs);}
+	unsigned char operator == (const char *cstr) const {return equals(cstr);}
+	unsigned char operator != (const String &rhs) const {return !equals(rhs);}
+	unsigned char operator != (const char *cstr) const {return !equals(cstr);}
+	unsigned char operator <  (const String &rhs) const;
+	unsigned char operator >  (const String &rhs) const;
+	unsigned char operator <= (const String &rhs) const;
+	unsigned char operator >= (const String &rhs) const;
+	unsigned char equalsIgnoreCase(const String &s) const;
+	unsigned char startsWith( const String &prefix) const;
+	unsigned char startsWith(const String &prefix, unsigned int offset) const;
+	unsigned char endsWith(const String &suffix) const;
+
+	// character acccess
+	char charAt(unsigned int index) const;
+	void setCharAt(unsigned int index, char c);
+	char operator [] (unsigned int index) const;
+	char& operator [] (unsigned int index);
+	void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index=0) const;
+	void toCharArray(char *buf, unsigned int bufsize, unsigned int index=0) const
+		{ getBytes((unsigned char *)buf, bufsize, index); }
+	const char* c_str() const { return buffer; }
+	char* begin() { return buffer; }
+	char* end() { return buffer + length(); }
+	const char* begin() const { return c_str(); }
+	const char* end() const { return c_str() + length(); }
+
+	// search
+	int indexOf( char ch ) const;
+	int indexOf( char ch, unsigned int fromIndex ) const;
+	int indexOf( const String &str ) const;
+	int indexOf( const String &str, unsigned int fromIndex ) const;
+	int lastIndexOf( char ch ) const;
+	int lastIndexOf( char ch, unsigned int fromIndex ) const;
+	int lastIndexOf( const String &str ) const;
+	int lastIndexOf( const String &str, unsigned int fromIndex ) const;
+	String substring( unsigned int beginIndex ) const { return substring(beginIndex, len); };
+	String substring( unsigned int beginIndex, unsigned int endIndex ) const;
+
+	// modification
+	void replace(char find, char replace);
+	void replace(const String& find, const String& replace);
+	void remove(unsigned int index);
+	void remove(unsigned int index, unsigned int count);
+	void toLowerCase(void);
+	void toUpperCase(void);
+	void trim(void);
+
+	// parsing/conversion
+	long toInt(void) const;
+	float toFloat(void) const;
+	double toDouble(void) const;
+
+protected:
+	char *buffer;	        // the actual char array
+	unsigned int capacity;  // the array length minus one (for the '\0')
+	unsigned int len;       // the String length (not counting the '\0')
+protected:
+	void init(void);
+	void invalidate(void);
+	unsigned char changeBuffer(unsigned int maxStrLen);
+	unsigned char concat(const char *cstr, unsigned int length);
+
+	// copy and move
+	String & copy(const char *cstr, unsigned int length);
+	String & copy(const __FlashStringHelper *pstr, unsigned int length);
+       #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	void move(String &rhs);
+	#endif
+};
+
+class StringSumHelper : public String
+{
+public:
+	StringSumHelper(const String &s) : String(s) {}
+	StringSumHelper(const char *p) : String(p) {}
+	StringSumHelper(char c) : String(c) {}
+	StringSumHelper(unsigned char num) : String(num) {}
+	StringSumHelper(int num) : String(num) {}
+	StringSumHelper(unsigned int num) : String(num) {}
+	StringSumHelper(long num) : String(num) {}
+	StringSumHelper(unsigned long num) : String(num) {}
+	StringSumHelper(float num) : String(num) {}
+	StringSumHelper(double num) : String(num) {}
+};
+
+#endif  // __cplusplus
+#endif  // String_class_h
+

--- a/DynamixelWorkbench/include/dynamixel_workbench_toolbox/p_monitor.h
+++ b/DynamixelWorkbench/include/dynamixel_workbench_toolbox/p_monitor.h
@@ -1,6 +1,9 @@
-#define "P_MONITOR.h"
+#ifndef P_MONITOR_H
+#define P_MONITOR_H
+
 #include "WString.h"
+
 void dynamixel_command(String cmd[]);
+void split(String data, char separator, String* temp);
 
-
-#endif //"P_MONITOR
+#endif //P_MONITOR

--- a/DynamixelWorkbench/include/dynamixel_workbench_toolbox/p_monitor.h
+++ b/DynamixelWorkbench/include/dynamixel_workbench_toolbox/p_monitor.h
@@ -1,0 +1,6 @@
+#define "P_MONITOR.h"
+#include "WString.h"
+void dynamixel_command(String cmd[]);
+
+
+#endif //"P_MONITOR

--- a/DynamixelWorkbench/src/dynamixel_workbench_toolbox/monitor.cpp
+++ b/DynamixelWorkbench/src/dynamixel_workbench_toolbox/monitor.cpp
@@ -1,0 +1,678 @@
+/*******************************************************************************
+* Copyright 2016 ROBOTIS CO., LTD.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/* Authors: Taehun Lim (Darby) */
+
+/* Modifications copyright (C) 2019 Étienne Villemure*/
+
+#include <DynamixelWorkbench.h>
+
+#if defined(__OPENCM904__)
+  #define DEVICE_NAME "3" //Dynamixel on Serial3(USART3)  <-OpenCM 485EXP
+#elif defined(__OPENCR__)
+  #define DEVICE_NAME ""
+#endif   
+
+#define STRING_BUF_NUM 64
+//String cmd[STRING_BUF_NUM];     //Modification: the cmd string list is now a parameter of dynamixel_command()
+
+DynamixelWorkbench dxl_wb;
+uint8_t get_id[16];
+uint8_t scan_cnt = 0;
+uint8_t ping_cnt = 0;
+
+bool isAvailableID(uint8_t id);
+void split(String data, char separator, String* temp);
+void printInst();
+
+/*
+ * Function name: dynamixel_command()
+ * Paramters: cmd : Array of string that contains commands and parameters from serial
+ * Returns : Nothing
+ * 
+ * Description: Takes a dynamixelcommand and its parameters to send the appropriate command to the dynamixel
+ */
+
+void dynamixel_command(String cmd[])
+{
+  const char *log = NULL;
+  bool result = false;
+
+  {
+    if (cmd[0] == "help")
+    {
+      //printInst();
+    }
+    else if (cmd[0] == "begin")
+    {
+      if (cmd[1] == '\0')
+        cmd[1] = String("57600");
+
+      uint32_t baud = cmd[1].toInt();
+      result = dxl_wb.init(DEVICE_NAME, baud);
+      if (result == false)
+      {
+        Serial.println(log);
+        Serial.println("Failed to init");
+      }
+      else
+      {
+        Serial.print("Succeed to init : ");
+        Serial.println(baud);  
+      }
+    }
+    else if (cmd[0] == "end")
+    {        
+      return;
+    }
+    else if (cmd[0] == "scan")
+    { 
+      if (cmd[1] == '\0')
+        cmd[1] = String("253");
+
+      uint8_t range = cmd[1].toInt();
+      result = dxl_wb.scan(get_id, &scan_cnt, range);
+      if (result == false)
+      {
+        Serial.println(log);
+        Serial.println("Failed to scan");
+      }
+      else
+      {
+        Serial.print("Find ");
+        Serial.print(scan_cnt);
+        Serial.println(" Dynamixels");
+
+        for (int cnt = 0; cnt < scan_cnt; cnt++)
+        {
+          Serial.print("id : ");
+          Serial.print(get_id[cnt]);
+          Serial.print(" model name : ");
+          Serial.println(dxl_wb.getModelName(get_id[cnt]));
+        }
+      }  
+    }
+    else if (cmd[0] == "ping")
+    {
+      if (cmd[1] == '\0')
+        cmd[1] = String("1");
+
+      get_id[ping_cnt] = cmd[1].toInt();
+      uint16_t model_number = 0;
+
+      result = dxl_wb.ping(get_id[ping_cnt], &model_number, &log);
+      if (result == false)
+      {
+        Serial.println(log);
+        Serial.println("Failed to ping");
+      }
+      else
+      {
+        ping_cnt++;
+
+        Serial.println("Succeed to ping");
+        Serial.print("id : ");
+        Serial.print(get_id[ping_cnt]);
+        Serial.print(" model_number : ");
+        Serial.println(model_number);
+      }
+    }
+    else if (isAvailableID(cmd[1].toInt()))
+    {
+      if (cmd[0] == "control_table")
+      {
+        uint8_t id = cmd[1].toInt();
+
+        const ControlItem *control_item =  dxl_wb.getControlTable(id);
+        uint8_t the_number_of_control_item = dxl_wb.getTheNumberOfControlItem(id);
+
+        uint16_t last_register_addr = control_item[the_number_of_control_item-1].address;
+        uint16_t last_register_addr_length = control_item[the_number_of_control_item-1].data_length;
+
+        uint32_t getAllRegisteredData[last_register_addr+last_register_addr_length];
+
+        if (control_item != NULL)
+        {
+          result = dxl_wb.readRegister(id, (uint16_t)0, last_register_addr+last_register_addr_length, getAllRegisteredData, &log);
+          if (result == false)
+          {
+            Serial.println(log);
+            return;
+          }
+          else
+          {
+            for (int index = 0; index < the_number_of_control_item; index++)
+            {
+              uint32_t data = 0;
+
+              if (dxl_wb.getProtocolVersion() == 2.0f)
+              {
+                data = getAllRegisteredData[control_item[index].address];
+                Serial.print("\t");
+                Serial.print(control_item[index].item_name);
+                Serial.print(" : ");
+                Serial.println(data);
+              }
+              else if (dxl_wb.getProtocolVersion() == 1.0f)
+              {
+                switch (control_item[index].data_length)
+                {
+                  case BYTE:
+                    data = getAllRegisteredData[control_item[index].address];
+                    Serial.print("\t");
+                    Serial.print(control_item[index].item_name);
+                    Serial.print(" : ");
+                    Serial.println(data);
+                    break;
+
+                  case WORD:
+                    data = DXL_MAKEWORD(getAllRegisteredData[control_item[index].address], getAllRegisteredData[control_item[index].address+1]);
+                    Serial.print("\t");
+                    Serial.print(control_item[index].item_name);
+                    Serial.print(" : ");
+                    Serial.println(data);
+                    break;
+
+                  case DWORD:
+                    data = DXL_MAKEDWORD(DXL_MAKEWORD(getAllRegisteredData[control_item[index].address],   getAllRegisteredData[control_item[index].address+1]),
+                                          DXL_MAKEWORD(getAllRegisteredData[control_item[index].address+2], getAllRegisteredData[control_item[index].address+3]));
+                    Serial.print("\t");
+                    Serial.print(control_item[index].item_name);
+                    Serial.print(" : ");
+                    Serial.println(data);
+                    break;
+
+                  default:
+                    data = getAllRegisteredData[control_item[index].address];
+                    break;
+                } 
+              }
+            }
+          }
+        }
+      }
+      else if (cmd[0] == "sync_write_handler")
+      {
+        static uint8_t sync_write_handler_index = 0;
+        uint8_t id = cmd[1].toInt();
+
+        result = dxl_wb.addSyncWriteHandler(id, cmd[2].c_str(), &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to add sync write handler\n");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+          Serial.print("sync_write_handler_index = ");
+          Serial.println(sync_write_handler_index);
+        }
+      }
+      else if (cmd[0] == "sync_read_handler")
+      {
+        static uint8_t sync_read_handler_index = 0;
+        uint8_t id = cmd[1].toInt();        
+
+        result = dxl_wb.addSyncReadHandler(id, cmd[2].c_str(), &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to add sync write handler\n");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+          Serial.print("sync_read_handler_index = ");
+          Serial.println(sync_read_handler_index);
+        }
+      }
+      else if (cmd[0] == "bulk_write_handler")
+      {
+        result = dxl_wb.initBulkWrite(&log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to init bulk write handler\n");
+          return;
+        }
+        else
+          Serial.println(log);
+      }
+      else if (cmd[0] == "bulk_write_param")
+      {
+        uint8_t id = cmd[1].toInt();
+
+        result = dxl_wb.addBulkWriteParam(id, cmd[2].c_str(), cmd[3].toInt(), &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to add param for bulk write\n");
+          return;
+        }
+        else
+          Serial.println(log);
+      }
+      else if (cmd[0] == "bulk_write")
+      {
+        result = dxl_wb.bulkWrite(&log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to bulk write\n");
+          return;
+        }
+        else
+          Serial.println(log);
+      }
+      else if (cmd[0] == "bulk_read_handler")
+      {
+        result = dxl_wb.initBulkRead(&log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to init bulk read handler\n");
+          return;
+        }
+        else
+          Serial.println(log);
+      }
+      else if (cmd[0] == "bulk_read_param")
+      {
+        uint8_t id = cmd[1].toInt();
+        result = dxl_wb.addBulkReadParam(id, cmd[2].c_str(), &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.print("Failed to add param for bulk read\n");
+          return;
+        }
+        else
+          Serial.println(log);
+      }
+      else if (cmd[0] == "bulk_read")
+      {
+        result = dxl_wb.bulkRead(&log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.println("Failed to bulk read");
+          return;
+        }
+        else
+          printf("%s\n", log);
+
+        int32_t get_data[dxl_wb.getTheNumberOfBulkReadParam()];
+        result = dxl_wb.getBulkReadData(&get_data[0], &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.println("Failed to get bulk read data");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+          for (uint8_t index = 0; index < dxl_wb.getTheNumberOfBulkReadParam(); index++)
+          {
+            Serial.print("data[");
+            Serial.print(index);
+            Serial.print("] : ");
+            Serial.print(get_data[index]);
+          }
+          Serial.println("");
+        }
+
+        dxl_wb.clearBulkReadParam();
+      }
+      else if (isAvailableID(cmd[1].toInt()) && isAvailableID(cmd[2].toInt()))
+      {
+        if (cmd[0] == "sync_write")
+        {
+          uint8_t id_1 = cmd[1].toInt();
+          uint8_t id_2 = cmd[2].toInt();
+          uint8_t id[2] = {id_1, id_2};
+          uint8_t id_num = 2;
+
+          int32_t data[2] = {0, 0};
+          data[0] = cmd[4].toInt();
+          data[1] = cmd[5].toInt();
+
+          uint8_t handler_index = cmd[3].toInt();
+
+          result = dxl_wb.syncWrite(handler_index, id, id_num, (int32_t *)data, 1, &log);
+          if (result == false)
+          {
+            Serial.println(log);
+            return;
+          }
+          else
+            Serial.println(log);
+        }
+        else if (cmd[0] == "sync_read")
+        {
+          uint8_t id_1 = cmd[1].toInt();
+          uint8_t id_2 = cmd[2].toInt();
+          uint8_t id[2] = {id_1, id_2};
+          uint8_t id_num = 2;
+
+          int32_t data[2] = {0, 0};
+          uint8_t handler_index = cmd[3].toInt();
+
+          result = dxl_wb.syncRead(handler_index, id, id_num, &log);
+          if (result == false)
+          {
+            Serial.println(log);
+            return;
+          }
+          else
+          {
+            Serial.println(log);
+          }
+
+          result = dxl_wb.getSyncReadData(handler_index, id, id_num, data, &log);
+          if (result == false)
+          {
+            Serial.println(log);
+            return;
+          }
+          else
+          {
+            Serial.println(log);
+            Serial.print("[ID ");
+            Serial.print(cmd[1].toInt());
+            Serial.print(" ]");
+            Serial.print(" data : ");
+            Serial.println(data[0]);
+            Serial.print("[ID ");
+            Serial.print(cmd[2].toInt());
+            Serial.print(" ]");
+            Serial.print(" data : ");
+            Serial.println(data[0]);
+          }
+        }
+      }
+      else if (cmd[0] == "id")
+      {
+        uint8_t id     = cmd[1].toInt();
+        uint8_t new_id = cmd[2].toInt();
+
+        result = dxl_wb.changeID(id, new_id, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "baud")
+      {
+        uint8_t  id       = cmd[1].toInt();
+        uint32_t  new_baud  = cmd[2].toInt();
+
+        result = dxl_wb.changeBaudrate(id, new_baud, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return ;
+        }
+        else
+        {
+          result = dxl_wb.setBaudrate(new_baud, &log);
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "torque_on")
+      {
+        uint8_t id       = cmd[1].toInt();
+
+        result = dxl_wb.torqueOn(id, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "torque_off")
+      {
+        uint8_t id       = cmd[1].toInt();
+
+        result = dxl_wb.torqueOff(id, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "joint")
+      {
+        uint8_t id    = cmd[1].toInt();
+        uint16_t goal = cmd[2].toInt();
+
+        result = dxl_wb.jointMode(id, 0, 0, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+
+        result = dxl_wb.goalPosition(id, (int32_t)goal, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "wheel")
+      {
+        uint8_t id    = cmd[1].toInt();
+        int32_t goal  = cmd[2].toInt();
+
+        result = dxl_wb.wheelMode(id, 0, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+
+        result = dxl_wb.goalVelocity(id, (int32_t)goal, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "write")
+      {
+        uint8_t id = cmd[1].toInt();      
+        uint32_t value = cmd[3].toInt(); 
+
+        result = dxl_wb.writeRegister(id, cmd[2].c_str(), value, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.println("Failed to write");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "read")
+      {
+        uint8_t id = cmd[1].toInt();
+
+        int32_t data = 0;
+        
+        result = dxl_wb.readRegister(id, cmd[2].c_str(), &data, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.println("Failed to read");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+          Serial.print("read data : ");
+          Serial.println(data);
+        }
+      }
+      else if (cmd[0] == "reboot")
+      {
+        uint8_t id = cmd[1].toInt();
+
+        result = dxl_wb.reboot(id, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.println("Failed to reboot");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else if (cmd[0] == "reset")
+      {
+        uint8_t id = cmd[1].toInt();
+
+        result = dxl_wb.reset(id, &log);
+        if (result == false)
+        {
+          Serial.println(log);
+          Serial.println("Failed to reset");
+          return;
+        }
+        else
+        {
+          Serial.println(log);
+        }
+      }
+      else 
+      {
+        Serial.println("Wrong command");
+      }
+    }
+    else 
+    {
+      Serial.println("Please check ID");
+    }
+  }
+}
+
+void split(String data, char separator, String* temp)
+{
+	int cnt = 0;
+	int get_index = 0;
+
+  String copy = data;
+  
+	while(true)
+	{
+		get_index = copy.indexOf(separator);
+
+		if(-1 != get_index)
+		{
+			temp[cnt] = copy.substring(0, get_index);
+
+			copy = copy.substring(get_index + 1);
+		}
+		else
+		{
+      temp[cnt] = copy.substring(0, copy.length());
+			break;
+		}
+		++cnt;
+	}
+}
+
+bool isAvailableID(uint8_t id)
+{
+  for (int dxl_cnt = 0; dxl_cnt < (scan_cnt + ping_cnt); dxl_cnt++)
+  {
+    if (get_id[dxl_cnt] == id)
+      return true;
+  }
+
+  return false;
+}
+
+void printInst(void)
+{
+//  Serial.print("-------------------------------------\n");
+//  Serial.print("Set begin before scan or ping\n");
+//  Serial.print("-------------------------------------\n");
+//  Serial.print("help\n");
+//  Serial.print("begin  (BAUD)\n");
+//  Serial.print("scan   (RANGE)\n");
+//  Serial.print("ping   (ID)\n");
+//  Serial.print("control_table (ID)\n");
+//  Serial.print("id     (ID) (NEW_ID)\n");
+//  Serial.print("baud   (ID) (NEW_BAUD)\n");
+//  Serial.print("torque_on (ID)\n");
+//  Serial.print("torque_off (ID)\n");
+//  Serial.print("joint  (ID) (GOAL_POSITION)\n");
+//  Serial.print("wheel  (ID) (GOAL_VELOCITY)\n");
+//  Serial.print("write  (ID) (ADDRESS_NAME) (DATA)\n");
+//  Serial.print("read   (ID) (ADDRESS_NAME)\n");
+//  Serial.print("sync_write_handler (Ref_ID) (ADDRESS_NAME)\n");
+//  Serial.print("sync_write (ID_1) (ID_2) (HANDLER_INDEX) (PARAM_1) (PARAM_2)\n");
+//  Serial.print("sync_read_handler (Ref_ID) (ADDRESS_NAME)\n");
+//  Serial.print("sync_read (ID_1) (ID_2) (HANDLER_INDEX)\n");
+//  Serial.print("bulk_write_handler\n");
+//  Serial.print("bulk_write_param (ID) (ADDRESS_NAME) (PARAM)\n");
+//  Serial.print("bulk_write\n");
+//  Serial.print("bulk_read_handler\n");
+//  Serial.print("bulk_read_param (ID) (ADDRESS_NAME)\n");
+//  Serial.print("bulk_read\n");
+//  Serial.print("reboot (ID) \n");
+//  Serial.print("reset  (ID) \n");
+//  Serial.print("end\n");
+//  Serial.print("-------------------------------------\n");
+//  Serial.print("Press Enter Key\n");
+}

--- a/DynamixelWorkbench/src/dynamixel_workbench_toolbox/p_monitor.cpp
+++ b/DynamixelWorkbench/src/dynamixel_workbench_toolbox/p_monitor.cpp
@@ -19,6 +19,7 @@
 /* Modifications copyright (C) 2019 Étienne Villemure*/
 
 #include <DynamixelWorkbench.h>
+#include <p_monitor.h>
 
 #if defined(__OPENCM904__)
   #define DEVICE_NAME "3" //Dynamixel on Serial3(USART3)  <-OpenCM 485EXP

--- a/DynamixelWorkbench/src/dynamixel_workbench_toolbox/p_monitor.cpp
+++ b/DynamixelWorkbench/src/dynamixel_workbench_toolbox/p_monitor.cpp
@@ -55,7 +55,7 @@ void dynamixel_command(String cmd[])
   {
     if (cmd[0] == "help")
     {
-      //printInst();
+      printInst();
     }
     else if (cmd[0] == "begin")
     {
@@ -645,35 +645,35 @@ bool isAvailableID(uint8_t id)
 
 void printInst(void)
 {
-//  Serial.print("-------------------------------------\n");
-//  Serial.print("Set begin before scan or ping\n");
-//  Serial.print("-------------------------------------\n");
-//  Serial.print("help\n");
-//  Serial.print("begin  (BAUD)\n");
-//  Serial.print("scan   (RANGE)\n");
-//  Serial.print("ping   (ID)\n");
-//  Serial.print("control_table (ID)\n");
-//  Serial.print("id     (ID) (NEW_ID)\n");
-//  Serial.print("baud   (ID) (NEW_BAUD)\n");
-//  Serial.print("torque_on (ID)\n");
-//  Serial.print("torque_off (ID)\n");
-//  Serial.print("joint  (ID) (GOAL_POSITION)\n");
-//  Serial.print("wheel  (ID) (GOAL_VELOCITY)\n");
-//  Serial.print("write  (ID) (ADDRESS_NAME) (DATA)\n");
-//  Serial.print("read   (ID) (ADDRESS_NAME)\n");
-//  Serial.print("sync_write_handler (Ref_ID) (ADDRESS_NAME)\n");
-//  Serial.print("sync_write (ID_1) (ID_2) (HANDLER_INDEX) (PARAM_1) (PARAM_2)\n");
-//  Serial.print("sync_read_handler (Ref_ID) (ADDRESS_NAME)\n");
-//  Serial.print("sync_read (ID_1) (ID_2) (HANDLER_INDEX)\n");
-//  Serial.print("bulk_write_handler\n");
-//  Serial.print("bulk_write_param (ID) (ADDRESS_NAME) (PARAM)\n");
-//  Serial.print("bulk_write\n");
-//  Serial.print("bulk_read_handler\n");
-//  Serial.print("bulk_read_param (ID) (ADDRESS_NAME)\n");
-//  Serial.print("bulk_read\n");
-//  Serial.print("reboot (ID) \n");
-//  Serial.print("reset  (ID) \n");
-//  Serial.print("end\n");
-//  Serial.print("-------------------------------------\n");
-//  Serial.print("Press Enter Key\n");
+  Serial.print("-------------------------------------\n");
+  Serial.print("Set begin before scan or ping\n");
+  Serial.print("-------------------------------------\n");
+  Serial.print("help\n");
+  Serial.print("begin  (BAUD)\n");
+  Serial.print("scan   (RANGE)\n");
+  Serial.print("ping   (ID)\n");
+  Serial.print("control_table (ID)\n");
+  Serial.print("id     (ID) (NEW_ID)\n");
+  Serial.print("baud   (ID) (NEW_BAUD)\n");
+  Serial.print("torque_on (ID)\n");
+  Serial.print("torque_off (ID)\n");
+  Serial.print("joint  (ID) (GOAL_POSITION)\n");
+  Serial.print("wheel  (ID) (GOAL_VELOCITY)\n");
+  Serial.print("write  (ID) (ADDRESS_NAME) (DATA)\n");
+  Serial.print("read   (ID) (ADDRESS_NAME)\n");
+  Serial.print("sync_write_handler (Ref_ID) (ADDRESS_NAME)\n");
+  Serial.print("sync_write (ID_1) (ID_2) (HANDLER_INDEX) (PARAM_1) (PARAM_2)\n");
+  Serial.print("sync_read_handler (Ref_ID) (ADDRESS_NAME)\n");
+  Serial.print("sync_read (ID_1) (ID_2) (HANDLER_INDEX)\n");
+  Serial.print("bulk_write_handler\n");
+  Serial.print("bulk_write_param (ID) (ADDRESS_NAME) (PARAM)\n");
+  Serial.print("bulk_write\n");
+  Serial.print("bulk_read_handler\n");
+  Serial.print("bulk_read_param (ID) (ADDRESS_NAME)\n");
+  Serial.print("bulk_read\n");
+  Serial.print("reboot (ID) \n");
+  Serial.print("reset  (ID) \n");
+  Serial.print("end\n");
+  Serial.print("-------------------------------------\n");
+  Serial.print("Press Enter Key\n");
 }

--- a/DynamixelWorkbench/src/p_monitor.h
+++ b/DynamixelWorkbench/src/p_monitor.h
@@ -1,0 +1,2 @@
+#include "../include/dynamixel_workbench_toolbox/p_monitor.h"
+


### PR DESCRIPTION
Modification du dynamixelworkbench en ajoutant l'exemple de p_monitor en librairies. En incluant, <p_monitor.h>, il est possible d'utiliser dynamixel_command(String Cmd[]) pour envoyer des commandes de dynamixel aux moteurs.

Il ne manquerait juste qu'à commenter les retours d'écriture de serial qui vont être lu par le raspberry pi.

Liste de commandes pouvant être envoyées:
help
begin  (BAUD)
scan   (RANGE)
ping   (ID)
control_table (ID)
id     (ID) (NEW_ID)
baud   (ID) (NEW_BAUD)
torque_on (ID)
torque_off (ID)
joint  (ID) (GOAL_POSITION)
wheel  (ID) (GOAL_VELOCITY)
write  (ID) (ADDRESS_NAME) (DATA)
read   (ID) (ADDRESS_NAME)
sync_write_handler (Ref_ID) (ADDRESS_NAME)
sync_write (ID_1) (ID_2) (HANDLER_INDEX) (PARAM_1) (PARAM_2)
sync_read_handler (Ref_ID) (ADDRESS_NAME)
sync_read (ID_1) (ID_2) (HANDLER_INDEX)
bulk_write_handler
bulk_write_param (ID) (ADDRESS_NAME) (PARAM)
bulk_write
bulk_read_handler
bulk_read_param (ID) (ADDRESS_NAME)
bulk_read
reboot (ID) 
reset  (ID) 
end